### PR TITLE
Skip `SecretsUsedInArgOrEnv` of Docker build checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # syntax = docker/dockerfile:1
+# check = skip=SecretsUsedInArgOrEnv
 FROM golang:1.23.0 AS build
 WORKDIR /usr/src
 COPY . /usr/src/


### PR DESCRIPTION
This PR configures check to skip [SecretsUsedInArgOrEnv](https://docs.docker.com/reference/build-checks/secrets-used-in-arg-or-env/) which is an obvious false positive:

![image](https://github.com/user-attachments/assets/0115f2dc-e1ba-43db-95f3-9adf49db7984)
